### PR TITLE
Added context for managing redirect instructions.

### DIFF
--- a/Behat/CommonContext/RedirectContext.php
+++ b/Behat/CommonContext/RedirectContext.php
@@ -33,23 +33,25 @@ class RedirectContext extends BehatContext
     /**
      * Follow redirect instructions.
      *
-     * @param   string  $actualPath
+     * @param   string  $location
      *
      * @return  void
      *
-     * @Then /^I (?:am|should be) redirected to "([^"]*)"$/
+     * @Then /^I (?:am|should be) redirected(?: to "([^"]*)")?$/
      */
-    public function iAmRedirectedTo($actualPath)
+    public function iAmRedirected($location = null)
     {
         $session = $this->getSession();
         $headers = $session->getResponseHeaders();
 
         assertArrayHasKey('Location', $headers, 'The response contains a "Location" header');
 
-        // TODO: Change from path based comparison to URI based comparison
-        $redirectComponents = parse_url($headers['Location']);
-
-        assertEquals($redirectComponents['path'], $actualPath, 'The "Location" header points to the correct URI');
+        if (null !== $location) {
+            // TODO: Change from path based comparison to URI based comparison
+            $redirectComponents = parse_url($headers['Location']);
+    
+            assertEquals($redirectComponents['path'], $location, 'The "Location" header points to the correct URI');
+        }
 
         $client = $this->getClient();
 


### PR DESCRIPTION
Assertions can give unexpected results when working with controllers that redirect after
`POST` or `PUT` requests. This context helps intercepting redirects for the `SymfonyDriver`
and `GouteDriver`.

I hope I gave enough credit where it was due, most of this code has been modified after some hints from @schmittjoh. If not, please let me know!
