### PR TITLE
[SymfonyDoctrineContext] Fixed exceeding max connections limit

### DIFF
--- a/Behat/CommonContext/SymfonyDoctrineContext.php
+++ b/Behat/CommonContext/SymfonyDoctrineContext.php
@@ -22,9 +22,15 @@ class SymfonyDoctrineContext extends BehatContext
      *
      * @return null
      */
-    public function beforeScenario($event)
+    public function buildSchema($event)
     {
-        $this->buildSchema();
+        $metadata = $this->getMetadata();
+
+        if (!empty($metadata)) {
+            $tool = new SchemaTool($this->getEntityManager());
+            $tool->dropSchema($metadata);
+            $tool->createSchema($metadata);
+        }
     }
 
     /**
@@ -34,26 +40,12 @@ class SymfonyDoctrineContext extends BehatContext
      *
      * @return null
      */
-    public function afterScenario($event)
+    public function closeDBALConnections($event)
     {
         $this->getEntityManager()->clear();
 
         foreach ($this->getClientConnections() as $connection) {
             $connection->close();
-        }
-    }
-
-    /**
-     * @return null
-     */
-    protected function buildSchema()
-    {
-        $metadata = $this->getMetadata();
-
-        if (!empty($metadata)) {
-            $tool = new SchemaTool($this->getEntityManager());
-            $tool->dropSchema($metadata);
-            $tool->createSchema($metadata);
         }
     }
 


### PR DESCRIPTION
It caused random scenarios to fail with large scenario suites.

To fix the issue I'm closing client connections. They were being left in sleep state and cumulating until behat process was finished.

There are still some connections cumulating. Those are established by behat's entity manager and cannot be closed automatically as user might need to do some cleanups before.
