### PR TITLE
Made it easier to use MinkContext as a subcontext

### DIFF
--- a/Behat/CommonContexts/RedirectContext.php
+++ b/Behat/CommonContexts/RedirectContext.php
@@ -96,6 +96,9 @@ class RedirectContext extends BehatContext
     /**
      * Returns current active mink session.
      *
+     * If you are using MinkContext as a subcontext instead of using it as
+      * the main one, overwrite this method
+     *
      * @return  Behat\Mink\Session
      */
     protected function getSession()

--- a/Behat/CommonContexts/SymfonyDoctrineContext.php
+++ b/Behat/CommonContexts/SymfonyDoctrineContext.php
@@ -71,7 +71,7 @@ class SymfonyDoctrineContext extends BehatContext
     protected function getConnections()
     {
         if ($this->getContainer()->has('behat.mink')) {
-            $driver = $this->getMainContext()->getSession()->getDriver();
+            $driver = $this->getMinkContext()->getSession()->getDriver();
 
             if ($driver instanceof \Behat\MinkBundle\Driver\SymfonyDriver) {
                 return $driver->getClient()->getContainer()->get('doctrine')->getConnections();
@@ -79,5 +79,18 @@ class SymfonyDoctrineContext extends BehatContext
         }
 
         return $this->getContainer()->get('doctrine')->getConnections();
+    }
+
+    /**
+     * Gets the Mink context.
+     *
+     * If you are using MinkContext as a subcontext instead of using it as
+     * the main one, overwrite this method
+     *
+     * @return \Behat\Mink\Behat\Context\BaseMinkContext
+     */
+    protected function getMinkContext()
+    {
+        return $this->getMainContext();
     }
 }

--- a/Behat/CommonContexts/SymfonyExtraContext.php
+++ b/Behat/CommonContexts/SymfonyExtraContext.php
@@ -85,12 +85,13 @@ class SymfonyExtraContext extends BehatContext
      * be used.
      *
      * @param string $token
+     * @return \Symfony\Component\HttpKernel\Profiler\Profile
      * @throws \RuntimeException
      */
     public function loadProfile($token = null)
     {
         if (null === $token) {
-            $headers = $this->getMainContext()->getSession()->getResponseHeaders();
+            $headers = $this->getMinkContext()->getSession()->getResponseHeaders();
 
             if (!isset($headers['X-Debug-Token']) && !isset($headers['x-debug-token'])) {
                 throw new \RuntimeException('Debug-Token not found in response headers. Have you turned on the debug flag?');
@@ -99,5 +100,18 @@ class SymfonyExtraContext extends BehatContext
         }
 
         return $this->kernel->getContainer()->get('profiler')->loadProfile($token);
+    }
+
+    /**
+     * Gets the Mink context.
+     *
+     * If you are using MinkContext as a subcontext instead of using it as
+     * the main one, overwrite this method
+     *
+     * @return \Behat\Mink\Behat\Context\BaseMinkContext
+     */
+    protected function getMinkContext()
+    {
+        return $this->getMainContext();
     }
 }


### PR DESCRIPTION
The common context now have a method which can be overwritten when
the MinkContext is not the main context but a subcontext.
what do you think about it ?
