### PR TITLE
fix BehatContext old class use clause

### DIFF
--- a/Behat/CommonContexts/SymfonyDoctrineContext.php
+++ b/Behat/CommonContexts/SymfonyDoctrineContext.php
@@ -2,7 +2,7 @@
 
 namespace Behat\CommonContexts;
 
-use Behat\BehatBundle\Context\BehatContext;
+use Behat\Behat\Context\BehatContext;
 use Behat\Behat\Event\ScenarioEvent;
 use Doctrine\ORM\Tools\SchemaTool;
 


### PR DESCRIPTION
just missed switching this class as well

I am doing this now, hope it is ok with behat 2.4

``` php
public function __construct(array $parameters)
    {
        $this->parameters = $parameters;
        $this->useContext('api', new WebApiContext($parameters['base_url']));
        $this->useContext('symfony_doctrine', new SymfonyDoctrineContext());
        $this->useContext('mink_redirect', new MinkRedirectContext());
        $this->useContext('mink_extra', new MinkExtraContext())
    }
```

also common-contexts is too small i guess to have a develop branch so I am PR'eing master
