### PR TITLE
Hi guys!

### DIFF
--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -195,8 +195,9 @@ class WebApiContext extends BehatContext
         }
 
         assertCount(count($etalon), $actual);
-        foreach ($actual as $needle) {
-            assertContains($needle, $etalon);
+        foreach ($actual as $key => $needle) {
+            assertArrayHasKey($key, $etalon);
+            assertEquals($etalon[$key], $actual[$key]);
         }
     }
 


### PR DESCRIPTION
I think, that this method works incorrect.

In our project we have REST and the server returns a response in json format. One day, the server has changed a key. But at the same time continued to pass the tests and the error was discovered only accidentally discovered.

I think we should be checking for the key, there may be a key is more important than the match value.

As for checking the value. If we check the existence of a key, and the value should be checked on the key.

I look forward to your opinions.

Regards,
Dmitry.
