### PR TITLE
Fixes double authorization headers

### DIFF
--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -51,6 +51,7 @@ class WebApiContext extends BehatContext
      */
     public function iAmAuthenticatingAs($username, $password)
     {
+        $this->removeHeader('Authorization');
         $this->authorization = base64_encode($username.':'.$password);
         $this->addHeader('Authorization: Basic '.$this->authorization);
     }
@@ -276,5 +277,19 @@ class WebApiContext extends BehatContext
     protected function addHeader($header)
     {
         $this->headers[] = $header;
+    }
+    
+    /**
+     * Removes a header identified by $headerName
+     *
+     * @param string $headerName
+     */
+    protected function removeHeader($headerName)
+    {
+        foreach ($this->headers as $headerIndex => $headerValue) {
+            if (strpos($headerValue, $headerName) === 0) {
+                unset($this->headers[$headerIndex]);
+            }
+        }
     }
 }


### PR DESCRIPTION
When using different HTTP basic credentials for separate requests, previous authentication headers are not cleared before adding the new ones.  As a consequence the request never gets authorized.

Signed-off-by: James Cauwelier james.cauwelier@gmail.com
