### PR TITLE
Fix checks for relative redirects

### DIFF
--- a/Behat/CommonContexts/MinkRedirectContext.php
+++ b/Behat/CommonContexts/MinkRedirectContext.php
@@ -67,7 +67,7 @@ class MinkRedirectContext extends RawMinkContext
                 $header = current($header);
             }
 
-            assertEquals($header, $this->locatePath($page), 'The "Location" header points to the correct URI');
+            assertEquals($header, $page, 'The "Location" header points to the correct URI');
         }
 
         $client = $this->getClient();


### PR DESCRIPTION
Maybe it's me doing something wrong, but I think calling `locatePath()` on the expected URL breaks checks on relative redirects.
