### PR TITLE
make mailer context compatible with SwiftMailerBundle v2.3.3 and v2.2.5

### DIFF
--- a/Behat/CommonContexts/SymfonyMailerContext.php
+++ b/Behat/CommonContexts/SymfonyMailerContext.php
@@ -51,7 +51,7 @@ class SymfonyMailerContext extends RawMinkContext implements KernelAwareInterfac
 
         $foundToAddresses = null;
         $foundSubjects = array();
-        foreach ($mailer->getMessages() as $message) {
+        foreach ($mailer->getMessages('default') as $message) {
             $foundSubjects[] = $message->getSubject();
 
             if (trim($subject) === trim($message->getSubject())) {


### PR DESCRIPTION
This breaks compatibility with previous versions of SwiftMailerBundle, thoughts?
