### PR TITLE
Implement Step for Checking the Response Header

### DIFF
--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -177,7 +177,35 @@ class WebApiContext extends BehatContext
         assertNotRegExp('/'.preg_quote($text).'/', $this->browser->getLastResponse()->getContent());
     }
 
-    /**
+	/**
+	 * Checks that response Header contains specific text.
+	 *
+	 * @param string $header
+	 *
+	 * @param string $type
+	 *
+	 * @Then /^(?:the )?response header "([^"]*)" should contain "([^"]*)"$/
+	 */
+	public function theResponseHeaderShouldContain($header, $type)
+	{
+		assertRegExp('/'.preg_quote($type).'/', $this->browser->getLastResponse()->getHeader($header));
+	}
+
+	/**
+	 * Checks that response Header doesn't contains specific text.
+	 *
+	 * @param string $header
+	 *
+	 * @param string $type
+	 *
+	 * @Then /^(?:the )?response header "([^"]*)" should not contain "([^"]*)"$/
+	 */
+	public function theResponseHeaderShouldNotContain($header, $type)
+	{
+		assertNotRegExp('/'.preg_quote($type).'/', $this->browser->getLastResponse()->getHeader($header));
+	}
+
+	/**
      * Checks that response body contains JSON from PyString.
      *
      * @param PyStringNode $jsonString


### PR DESCRIPTION
This Step let you check if the Response Header contains (or should not contain) a specific text.

For Example:
And response header "Content-Type" should contain "json"

This allows you to check if the Content-Type from the server returns json. The Step is generic so you can check any Header.
