### PR TITLE
implement step for count response items (in case of array)

### DIFF
--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -177,7 +177,21 @@ class WebApiContext extends BehatContext
         assertNotRegExp('/'.preg_quote($text).'/', $this->browser->getLastResponse()->getContent());
     }
 
-    /**
+	/**
+	 * Checks that response body contains JSON data.
+	 *
+	 * @param int $count
+	 *
+	 * @Then /^(?:the )?response should contain (\d+) json items$/
+	 */
+	public function theResponseShouldContainJsonItems($count)
+	{
+		$actual = json_decode($this->browser->getLastResponse()->getContent(), true);
+
+		assertCount(intval($count), $actual);
+	}
+
+	/**
      * Checks that response body contains JSON from PyString.
      *
      * @param PyStringNode $jsonString
@@ -201,7 +215,7 @@ class WebApiContext extends BehatContext
             assertEquals($etalon[$key], $actual[$key]);
         }
     }
-
+	
     /**
      * Prints last response body.
      *


### PR DESCRIPTION
This step allows you to check the count of items you get from a resource and it is supposed for tests against list resources (get all items).

For Example:
And response should contain 9 json items

This also allows you to check filters on your resource.
