### PR TITLE
implement some rudiment json part test

### DIFF
--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -202,6 +202,18 @@ class WebApiContext extends BehatContext
         }
     }
 
+	/**
+	 * Checks that response body contains data from PyString.
+	 *
+	 * @param PyStringNode $jsonString
+	 *
+	 * @Then /^(?:the )?response should contain data:$/
+	 */
+	public function theResponseShouldContainData(PyStringNode $jsonString)
+	{
+		assertRegExp('/'.preg_quote(trim($this->replacePlaceHolder($jsonString->getRaw()))).'/', $this->browser->getLastResponse()->getContent());
+	}
+
     /**
      * Prints last response body.
      *


### PR DESCRIPTION
while testing a list resource (get all items) i found it hard to check if specific parts of items are present. The simple theResponseShouldContainJson does not allow you to check for part of the data and the theResponseShouldContain does not work well with json data structure.

this allows you to use a PyStringNode to check for. It is not perfect but works for me.

For Example:
And response should contain data:
    """
      {"foo":null,"bar":null,"baz":1,"text":"My good text","description":null,"id":1}
    """

Theoretically you can test any data with it, not just json (no parsing/decoding included)
