### PR TITLE
Implemented step theResponseShouldContainPartialJson

### DIFF
--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -203,6 +203,11 @@ class WebApiContext extends BehatContext
     }
 
     /**
+     * Checks that response body contains JSON from PyString.
+     * Only the keys present in the etalon will be checked.
+     *
+     * @param PyStringNode $jsonString
+     *
      * @Then /^(?:the )?response should contain partial json:$/
      */
     public function theResponseShouldContainPartialJson(PyStringNode $jsonString)
@@ -217,6 +222,7 @@ class WebApiContext extends BehatContext
             );
         }
 
+        assertThat($actual, isType('array'));
         $this->assertArrayPartiallyEquals($etalon, $actual);
     }
 
@@ -230,6 +236,7 @@ class WebApiContext extends BehatContext
         foreach ($expected as $key => $value) {
             assertArrayHasKey($key, $actual);
             if (is_array($value)) {
+                assertThat($actual[$key], isType('array'));
                 $this->assertArrayPartiallyEquals($expected[$key], $actual[$key]);
             } else {
                 assertEquals($value, $actual[$key]);

--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -217,13 +217,9 @@ class WebApiContext extends BehatContext
             );
         }
 
-        $etalonKeys = array_keys($etalon);
-        $actualKeys = array_keys($actual);
-        $keys       = array_intersect($etalonKeys, $actualKeys);
-
-        foreach ($keys as $key) {
-            assertArrayHasKey($key, $etalon);
-            assertEquals($etalon[$key], $actual[$key]);
+        foreach ($etalon as $key => $value) {
+            assertArrayHasKey($key, $actual);
+            assertEquals($value, $actual[$key]);
         }
     }
 

--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -203,6 +203,31 @@ class WebApiContext extends BehatContext
     }
 
     /**
+     * @Given /^the response should contain partial json:$/
+     */
+    public function theResponseShouldContainPartialJson(PyStringNode $jsonString)
+    {
+
+        $etalon = json_decode($this->replacePlaceHolder($jsonString->getRaw()), true);
+        $actual = json_decode($this->browser->getLastResponse()->getContent(), true);
+
+        if (null === $etalon) {
+            throw new \RuntimeException(
+                "Can not convert etalon to json:\n".$this->replacePlaceHolder($jsonString->getRaw())
+            );
+        }
+
+        $etalonKeys = array_keys($etalon);
+        $actualKeys = array_keys($actual);
+        $keys       = array_intersect($etalonKeys, $actualKeys);
+
+        foreach ($keys as $key) {
+            assertArrayHasKey($key, $etalon);
+            assertEquals($etalon[$key], $actual[$key]);
+        }
+    }
+
+    /**
      * Prints last response body.
      *
      * @Then print response
@@ -279,7 +304,7 @@ class WebApiContext extends BehatContext
     {
         $this->headers[] = $header;
     }
-    
+
     /**
      * Removes a header identified by $headerName
      *

--- a/Behat/CommonContexts/WebApiContext.php
+++ b/Behat/CommonContexts/WebApiContext.php
@@ -203,7 +203,7 @@ class WebApiContext extends BehatContext
     }
 
     /**
-     * @Given /^the response should contain partial json:$/
+     * @Then /^(?:the )?response should contain partial json:$/
      */
     public function theResponseShouldContainPartialJson(PyStringNode $jsonString)
     {
@@ -217,9 +217,23 @@ class WebApiContext extends BehatContext
             );
         }
 
-        foreach ($etalon as $key => $value) {
+        $this->assertArrayPartiallyEquals($etalon, $actual);
+    }
+
+    /**
+     * Recursively checks that $actual contains the same key/values listed in $expected
+     * @param array $expected
+     * @param array $actual
+     */
+    protected function assertArrayPartiallyEquals(array $expected, array $actual)
+    {
+        foreach ($expected as $key => $value) {
             assertArrayHasKey($key, $actual);
-            assertEquals($value, $actual[$key]);
+            if (is_array($value)) {
+                $this->assertArrayPartiallyEquals($expected[$key], $actual[$key]);
+            } else {
+                assertEquals($value, $actual[$key]);
+            }
         }
     }
 


### PR DESCRIPTION
Does not check the whole JSON response keys per keys, but only the ones expected.
Useful for time changing properties, for example

Probably like #47
